### PR TITLE
rollout deployment after kubectl apply

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
       - run:
           name: 'kubectl apply'
           command: "kubectl apply --filename deploy/ --namespace formbuilder-submit-product-production"
+      - run:
+          name: 'rollout deployment'
+          command: "kubectl rollout restart deployments -n formbuilder-submit-product-production"
 
 workflows:
   version: 2


### PR DESCRIPTION
otherwise kubernetes does not pull latest image
and remains on the previous version