### PR TITLE
Update kubernetes resources

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: formbuilder-submit-product
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: formbuilder-submit-product
   template:
     metadata:
       labels:

--- a/deploy/ingress.yaml
+++ b/deploy/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: formbuilder-submit-product


### PR DESCRIPTION
Kubernetes has been upgraded to 1.16. These changes are required for the resources to continue working.

Followed the guide here:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html#resources-deployed-using-helm-charts

https://trello.com/c/w8d8G6RM/696-cloud-platform-kubernetes-update